### PR TITLE
Add remove/clear controls and a better preview

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -11,6 +11,7 @@ import PatchEvent, { set, unset, setIfMissing } from 'part:@sanity/form-builder/
 import { Heading } from './primitives';
 import Table from './table';
 import Button from 'part:@sanity/components/buttons/default'
+import ButtonGrid from 'part:@sanity/components/buttons/button-grid'
 
 /**
  * Container
@@ -66,6 +67,67 @@ class Container extends Component {
       columns: columns + 1,
       rows: rows === 0 ? 1 : rows,
     });
+  }
+
+  handleClear = () => {
+    const value = cloneDeep(this.props.value)
+    this.props.onChange(PatchEvent.from([
+      setIfMissing({ _type: 'table' }),
+      set({
+        ...value,
+        rows: value.rows.map(r => {
+          return {
+            ...r,
+            cells: r.cells.map(c => '')
+          }
+        })
+      })
+    ]))
+  }
+
+  handleRemoveRow = (index) => {
+    const value = cloneDeep(this.props.value)
+    this.props.onChange(PatchEvent.from([
+      setIfMissing({ _type: 'table' }),
+      set({
+        ...value,
+        rows: value.rows.filter((r, i) => i !== index)
+      })
+    ]))
+    this.setState({
+      rows: this.state.rows - 1
+    })
+  }
+
+  handleReset = (index) => {
+    const value = cloneDeep(this.props.value)
+    this.props.onChange(PatchEvent.from([
+      setIfMissing({ _type: 'table' }),
+      set({ ...value, rows: [] })
+    ]))
+    this.setState({
+      rows: 0,
+      columns: 0
+    })
+  }
+
+  handleRemoveColumn = (index) => {
+    const value = cloneDeep(this.props.value)
+    this.props.onChange(PatchEvent.from([
+      setIfMissing({ _type: 'table' }),
+      set({
+        ...value,
+        rows: value.rows.map(r => {
+          return {
+            ...r,
+            cells: r.cells.filter((c, i) => i !== index)
+          }
+        })
+      })
+    ]))
+    this.setState({
+      columns: this.state.columns - 1
+    })
   }
 
   /**
@@ -180,16 +242,21 @@ class Container extends Component {
           rows={rows}
           columns={columns}
           handleChange={this.handleCellChange}
+          onReset={this.handleReset}
+          onRemoveRow={this.handleRemoveRow}
+          onRemoveColumn={this.handleRemoveColumn}
         />
-        <Button
-          onClick={this.handleAddRow}
-          children={'Add row'}
-        />
-        <Button
-          onClick={this.handleAddColumn}
-          children={'Add column'}
-          style={{float: 'right'}}
-        />
+        <ButtonGrid>
+          <Button onClick={this.handleAddRow}>
+            Add row
+          </Button>
+          <Button onClick={this.handleAddColumn}>
+            Add column
+          </Button>
+          <Button onClick={this.handleClear} color="danger">
+            Empty cells
+          </Button>
+        </ButtonGrid>
       </div>
     );
   }

--- a/src/primitives.js
+++ b/src/primitives.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 /**
 * Primitives
@@ -13,16 +13,24 @@ export const Container = styled.div`
   width: 100%;
   background: none;
   margin-bottom: 1rem;
+  box-sizing: border-box;
 `;
 
 export const Row = styled.div`
+  box-sizing: border-box;
   width: 100%;
-  display: flex;
+  display: grid;
+  grid-gap: 2px;
+  grid-auto-flow: column;
+  ${props => css`
+    grid-template-columns: repeat(${props.cols}, 1fr) min-content;
+  `}
 `;
 
 export const Cell = styled.input`
   display: block;
   width: 100%;
+  box-sizing: border-box;
   border: none;
   background: #f2f2f2;
   margin: 1px;
@@ -35,6 +43,7 @@ export const Cell = styled.input`
 `;
 
 export const Empty = styled.div`
+  box-sizing: border-box;
   padding: .35rem;
   color: #666;
   letter-spacing: 1px;

--- a/src/schema/table.js
+++ b/src/schema/table.js
@@ -10,4 +10,26 @@ export default {
     of: [{type: 'column'}]
   }],
   inputComponent: Table,
+  preview: {
+    select: {
+      rows: 'rows',
+    },
+    prepare ({ rows }) {
+      const rowLength = rows.length || 0
+      const colLength = rowLength ? rows[0].cells.length : 0
+
+      if (rowLength === 0) {
+        return {
+          title: 'Empty table',
+          subtitle: ''
+        }
+      }
+      const headings = rows[0].cells
+
+      return {
+        title: headings.join(' | '),
+        subtitle: `${colLength} cols x ${rowLength} rows`,
+      }
+    }
+  }
 }

--- a/src/table.js
+++ b/src/table.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { range } from 'lodash';
 import PropTypes from 'prop-types';
+import Button from 'part:@sanity/components/buttons/default'
 
 import {  Container, Row, Cell, Empty } from './primitives';
 
@@ -9,25 +10,33 @@ const Table = (props) => {
     data,
     rows,
     columns,
-    handleChange
+    handleChange,
+    onRemoveRow,
+    onRemoveColumn,
+    onReset
   } = props;
 
   /**
   * Render rows
   */
 
-  const rowsList = range(rows).map(rowIndex => (
-    <Row key={rowIndex}>
+  const rowRange = range(rows)
+  const rowsList = rowRange.map(rowIndex => (
+    <Row key={rowIndex} cols={columns}>
       {range(columns).map(columnIndex => (
         <Cell
           key={columnIndex}
-          type="text"
+          type='text'
           value={(data[rowIndex] || [])[columnIndex] || ''}
           onChange={(e) => handleChange(e, rowIndex, columnIndex)}
         />
       ))}
+      <Button kind='simple' onClick={() => onRemoveRow(rowIndex)} title='Remove this row'>
+        -
+      </Button>
     </Row>
   ));
+
 
   /**
    * Render
@@ -39,6 +48,28 @@ const Table = (props) => {
         <Empty children="Empty table" />
       )}
       {rowsList}
+      {rows > 0 && (
+        <Row cols={columns}>
+          {range(columns).map(columnIndex => (
+            <Button
+              style={{width: '100%'}}
+              key={columnIndex}
+              kind='simple'
+              title='Remove this column'
+              onClick={() => onRemoveColumn(columnIndex)}
+            >
+              -
+            </Button>
+          ))}
+          <Button
+            color='danger'
+            onClick={onReset}
+            title='Remove all rows and columns'
+          >
+            &times;
+          </Button>
+        </Row>
+      )}
     </Container>
   );
 }


### PR DESCRIPTION
Halla Fredrik ;)

Well I guess I ended up using your plugin somewhere and found it lacking some crucial features to deal with modifying tables.
This adds the ability to:

- Remove a specific row
- Remove a specific column (across all rows)
- Remove all rows & columns
- Empty all cell values
- A better preview

See screens for what it basically adds:

![Screen Shot 2020-03-22 at 15 05 10](https://user-images.githubusercontent.com/45449/77251486-e1d06000-6c4e-11ea-8348-88e2411947cf.png)
![Screen Shot 2020-03-22 at 15 04 40](https://user-images.githubusercontent.com/45449/77251488-e4cb5080-6c4e-11ea-9fd7-239237f10ea3.png)
